### PR TITLE
`beartype` backend: Kermode Types

### DIFF
--- a/src/phantom/_base.py
+++ b/src/phantom/_base.py
@@ -8,22 +8,14 @@ from typing import Generic
 from typing import Iterable
 from typing import Iterator
 from typing import TypeVar
+from typing import Annotated
+
 
 from typing_extensions import Protocol
 from typing_extensions import runtime_checkable
 
-from ._utils.misc import BoundType
-from ._utils.misc import NotKnownMutableType
-from ._utils.misc import UnresolvedClassAttribute
-from ._utils.misc import fully_qualified_name
-from ._utils.misc import is_not_known_mutable_type
-from ._utils.misc import is_subtype
-from ._utils.misc import resolve_class_attr
-from .bounds import Parser
-from .bounds import get_bound_parser
-from .errors import BoundError
-from .predicates import Predicate
-from .schema import SchemaField
+from beartype.door import die_if_unbearable, is_bearable, TypeHint
+from beartype.vale._core._valecore import BeartypeValidator
 
 
 @runtime_checkable
@@ -32,7 +24,7 @@ class InstanceCheckable(Protocol):
         ...
 
 
-class PhantomMeta(abc.ABCMeta):
+class KermodeMeta(abc.ABCMeta):
     """
     Metaclass that defers __instancecheck__ to derived classes and prevents actual
     instance creation.
@@ -52,23 +44,19 @@ class PhantomMeta(abc.ABCMeta):
 
 
 T = TypeVar("T", covariant=True)
+Parser: TypeAlias = Callable[[object], T]
+Derived = TypeVar("Derived", bound="KermodeBase")
 
 
-Derived = TypeVar("Derived", bound="PhantomBase")
-
-
-class PhantomBase(SchemaField, metaclass=PhantomMeta):
+class KermodeBase(metaclass=KermodeMeta):
     @classmethod
     def parse(cls: type[Derived], instance: object) -> Derived:
         """
         Parse an arbitrary value into a phantom type.
-
         :raises TypeError:
         """
-        if not isinstance(instance, cls):
-            raise TypeError(
-                f"Could not parse {fully_qualified_name(cls)} from {instance!r}"
-            )
+        TypeHint(cls).die_if_unbearable(instance)
+
         return instance
 
     @classmethod
@@ -76,40 +64,51 @@ class PhantomBase(SchemaField, metaclass=PhantomMeta):
     def __instancecheck__(cls, instance: object) -> bool:
         ...
 
-    @classmethod
-    def __get_validators__(cls: type[Derived]) -> Iterator[Callable[[object], Derived]]:
-        """Hook that makes phantom types compatible with pydantic."""
-        yield cls.parse
 
-
-class AbstractInstanceCheck(TypeError):
+class UnresolvedClassAttribute(NotImplementedError):
     ...
 
 
-class MutableType(TypeError):
-    ...
+def resolve_class_attr(
+    cls: type,
+    name: str,
+    argument: object | None,
+    required: bool = True,
+) -> None:
+    argument = getattr(cls, name, None) if argument is None else argument
+    if argument is not None:
+        setattr(cls, name, argument)
+    elif required and not getattr(cls, "__abstract__", False):
+        raise UnresolvedClassAttribute(
+            f"Concrete phantom type {cls.__qualname__} must define class attribute "
+            f"{name}."
+        )
 
 
-class Phantom(PhantomBase, Generic[T]):
+def get_beartype_parser(beartype: type[T] | Any) -> Parser[T]:
+    def parser(instance: object) -> T:
+        TypeHint(cls).die_if_unbearable(instance)
+        return cast(T, instance)
+
+    return parser
+
+
+class Kermode(KermodeBase, Generic[T]):
     """
     Base class for predicate-based phantom types.
-
     **Class arguments**
-
-    * ``predicate: Predicate[T] | None`` - Predicate function used for instance checks.
+    * ``validator: BearTypeValidator | None`` - Predicate function used for instance checks.
       Can be ``None`` if the type is abstract.
-    * ``bound: type[T] | None`` - Bound used to check values before passing them to the
+    * ``beartype: type[T] | None`` - Bound used to check values before passing them to the
       type's predicate function. This will often but not always be the same as the
       runtime type that values of the phantom type are represented as. If this is not
       provided as a class argument, it's attempted to be resolved in order from an
       implicit bound (any bases of the type that come before ``Phantom``), or inherited
       from super phantom types that provide a bound. Can be ``None`` if the type is
       abstract.
-    * ``abstract: bool`` - Set to ``True`` to create an abstract phantom type. This
-      allows deferring definitions of ``predicate`` and ``bound`` to concrete subtypes.
     """
 
-    __predicate__: Predicate[T]
+    __validator__: BeartypeValidator
     # The bound of a phantom type is the type that its values will have at
     # runtime, so when checking if a value is an instance of a phantom type,
     # it's first checked to be within its bounds, so that the value can be
@@ -117,76 +116,66 @@ class Phantom(PhantomBase, Generic[T]):
     #
     # When subclassing, the bound of the new type must be a subtype of the bound
     # of the super class.
-    __bound__: ClassVar[NotKnownMutableType]
-    __abstract__: ClassVar[bool]
+    __beartype__: TypeHint
 
     def __init_subclass__(
         cls,
-        predicate: Predicate[T] | None = None,
-        bound: type[T] | None = None,
-        abstract: bool = False,
+        validator: BeartypeValidator | None = None,
+        beartype: type[T] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init_subclass__(**kwargs)
-        resolve_class_attr(cls, "__abstract__", abstract)
-        resolve_class_attr(cls, "__predicate__", predicate)
-        cls._resolve_bound(bound)
+        resolve_class_attr(cls, "__validator__", validator)
+
+        resolve_class_attr(cls, "__beartype__", TypeHint(cls))
+        cls._resolve_beartype(beartype)
 
     @classmethod
     def _interpret_implicit_bound(cls) -> BoundType:
-        def discover_bounds() -> Iterable[type]:
+        def discover_beartypes() -> Iterable[type]:
             for type_ in cls.__mro__:
                 if type_ is cls:
                     continue
-                if issubclass(type_, Phantom):
+                if TypeHint(type_).issubclass(Kermode):
                     break
                 yield type_
             else:  # pragma: no cover
                 raise RuntimeError(f"{cls} is not a subclass of Phantom")
 
-        types = tuple(discover_bounds())
+        types = tuple(discover_beartypes())
         if len(types) == 1:
             return types[0]
         return types
 
     @classmethod
-    def _resolve_bound(cls, class_arg: Any) -> None:
-        inherited = getattr(cls, "__bound__", None)
+    def _resolve_beartype(cls, class_arg: Any) -> None:
+        inherited = getattr(cls, "__beartype__", None)
         implicit = cls._interpret_implicit_bound()
-        if class_arg is not None:
+        validator = getattr(cls, "__validator__", name)
+        if class_arg is not None:  # told explicitly in `__init_subclass__(bound=...)`
             bound = class_arg
-        elif implicit:
+        elif implicit:  # told implicitly in MyClass(implicit, Kermode)
             bound = implicit
-        elif inherited is not None:
-            bound = inherited
-        elif not getattr(cls, "__abstract__", False):
-            raise UnresolvedClassAttribute(
-                f"Concrete phantom type {cls.__qualname__} must define class attribute "
-                f"__bound__."
-            )
+        elif inherited is not None:  # inherited via MyClass(MyBase(Kermode))
+            bound = inherited.hint
         else:
             return
-
-        if inherited is not None and not is_subtype(bound, inherited):
+        if validator is not None:
+            bound = Annotated[bound, validator]
+        if inherited is not None and not TypeHint(bound).is_subhint(inherited):
             raise BoundError(
                 f"The bound of {cls.__qualname__} is not compatible with its "
                 f"inherited bounds."
             )
 
-        if not is_not_known_mutable_type(bound):
-            raise MutableType(f"The bound of {cls.__qualname__} is mutable.")
-
-        cls.__bound__ = bound
+        cls.__beartype__ = TypeHint(bound)
 
     @classmethod
     def __instancecheck__(cls, instance: object) -> bool:
-        if cls.__abstract__:
-            raise AbstractInstanceCheck(
-                "Abstract phantom types cannot be used in instance checks"
-            )
-        bound_parser: Parser[T] = get_bound_parser(cls.__bound__)
+
+        bound_parser: Parser[T] = get_beartype_parser(cls.__beartype__)
         try:
             instance = bound_parser(instance)
         except BoundError:
             return False
-        return cls.__predicate__(instance)
+        return cls.__beartype__.is_bearable(instance)


### PR DESCRIPTION
Based on discussions in the beartype repo

## actions 

- remove extraneous (for now) pydantic support
- short-circuit instance-check when __beartype__ is present
- remove dependencies on external files (for now) to allow individual tests
- rename __predicate__ to __validator__ to match `beartype.vale`, changing the system to use the `BearTypeValidator` annotations rather than predicate functions (since those can be added into `beartype.vale.Is` directly, anyway). 
- rename __bound__` to `__beartype__` to match previous protocol discussions

## What is this? 

### motivation

The reason I found beartype was from [mentions in `classes`](https://classes.readthedocs.io/en/latest/pages/concept.html#phantom-types) where containers were called out as especially slow to `__instance_check__`, and `beartype` was a possible answer (read that link for context). SO, what does "using beartype" here actually look like? 

- beartype does in fact do things blazingly fast
- beartype does allow generic validation (e.g. not stuck inside the pydantic/marrow/zope/marshmallow ecosystem and, importantly, type hierarchy)
- beartype did _not_ allow us to know at runtime a `type_of` for things like dispatch, see `plum`'s Ver. 2 proposal for more on that. 
- beartype did not provide a mechanism to interop with other libraries directly, instead being _generally_ applicable as a drop-in pep-compliant type _enforcer_. `phantom-types` even showcased this in their readme, showing beartype could force phantom-type runtime correctness for instances. 

Those last two are problematic if we want to do introspection, like allowing user-plugins, or custom type hierarchies etc. 

### so...?

phantom types lets us build a custom hierarchy _purely out of predicates_, and hacking the `NewType` pattern to let MyPy stay happy _and_ runtime shennanigans occur. It uses 

- `__instance_check__` to override how instances are check for runtime asserts and static type-narrowing (i.e. to use predicates along with inheritance)
- `__call__` override to keep us from ever actually instancing our new types until we _reeaally_ want to. the new types are like "phantoms" (eyy) that live as metadata on normal python types. BUT, the type checker takes them seriously at runtime, and they can be "parsed" as needed to get instantiated for introspection. 

This is all great, but relies on a _lot_ of logic shennanigans to resolve the various ways in which a phantom might come to exist (implicitly, inherited, as a `__subclass_init_` argument, etc). Then there's an entire custom set of `type_of` rules (_verrry_ similar to the one `plum` had built, mind you!) to make sure we don't strictly listen to the evil python type hierarchy sirens, dashing into the rocks of insanity. 

This fork just does that stuff, but with the ear-beeswax of _beartype_ instead. 

- we replace the `__bound__` logic with the new `TypeHint` DOOR API, which implements a true poset of types to play with and modify. 
- we persist that logic as metadata attached to custom types in the form of a `__beartype__` dunder/magic, which alerts the runtime and type-checker systems that __instance_check__ NEEDS TO BE DONE USING `TypeHint` NOT `isinstance` calls!
- we allow users to do this using inheritance on types, or explicit beartype calls (when e.g. python prevents us from subclassing, say, `Union`.... ugh. 


## Should this actually happen? 
No

I don't really plan on doing this PR. It's a proof of concept that let me show others what diffs I _thought_ were needed to switch `phantom-types` to a `beartype` backend, and this is what I need serious oversight for. 

As for what we do going forward, I believe the new beartype plugin plan is going to give us something like `__beartype__` as a fully supported extension mechanism, at which point either

- @leycec can add something like `Kermode` as a new TypeHint extension API, duplicating a simplified version of phantom-types in-house, _or_ 
- the phantom-types library can allow users to optionally rely on beartype for bound resolution by adding an adapter, like they did with pydantic support previously. 
